### PR TITLE
fix: paper_scraper cron を 02:00 JST に前倒し

### DIFF
--- a/.github/workflows/paper_scraper.yml
+++ b/.github/workflows/paper_scraper.yml
@@ -3,7 +3,7 @@ name: 論文スクレイパーの実行
 on:
   schedule:
     # - cron: '00 11 * * 1-5'  # 月曜日から金曜日の19:30 JST（10:30 UTC）に実行
-    - cron: '00 20 * * *'  # 毎日JST朝5時（20:00 UTC）に実行
+    - cron: '00 17 * * *'  # 毎日 02:00 JST（17:00 UTC）に実行
   workflow_dispatch:  # 手動実行のオプション
 
 permissions:


### PR DESCRIPTION
Actions の遅延（最大約1時間45分）を考慮し、AI Mail Digest の取得窓（05:00 JST締め）に余裕を持って間に合わせるため、cron を `00 20 * * *`（05:00 JST）から `00 17 * * *`（02:00 JST）に前倒しします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the scheduled execution time for the paper scraper workflow. The scraper will now run at a different time each day.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fulfulggg/Information-gathering/pull/11077?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->