### PR TITLE
fix: 論文スクレイパーの恒久対策（HF公式API化・arXiv Atom API化・dedup・結果ベースfail-loud）

### DIFF
--- a/.github/scripts/scraper.py
+++ b/.github/scripts/scraper.py
@@ -2,6 +2,8 @@ import feedparser
 import json
 import re
 import os
+import sys
+import time
 import requests
 from bs4 import BeautifulSoup
 from loguru import logger
@@ -11,145 +13,212 @@ from art import *
 logger.remove()
 logger.add(lambda msg: print(msg, end=""), colorize=True, format="<green>{time:YYYY-MM-DD at HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{message}</cyan>")
 
+# --- 取得元設定 ---
+# arXiv は RSS(export.arxiv.org/rss/cs.AI) が間欠的に0件を返すため、Atom API に寄せる
+# （ai_mail_digest の paper_sources.py と同じ取得手法。submittedDate 降順で週末でも空にならない）。
+_ARXIV_API = 'http://export.arxiv.org/api/query'
+_ARXIV_CATEGORIES = ('cs.AI', 'cs.LG', 'cs.CL')
+_ARXIV_MAX_RESULTS = 50  # issue化は先頭30件のみ（issue_creator）なので数百件は不要
+# HuggingFace は rsshub.app が恒常403のため、HF サイト自身が使う daily_papers エンドポイントへ。
+_HF_API = 'https://huggingface.co/api/daily_papers'
+_REQUEST_RETRIES = 3
+_REQUEST_TIMEOUT = 30
+
+
 class PaperScraper:
     def __init__(self, output_path='./papers.json'):
         self.output_path = output_path
+        # API 取得用のシンプルなヘッダ（旧 self.headers の Accept-Encoding: br/zstd 等は
+        # デコード不能で不安定になり得るため、UA のみに絞る）。
         self.headers = {
             'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
-            'Referer': 'https://www.google.com/',
-            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-            'Accept-Encoding': 'gzip, deflate, br, zstd',
-            'Accept-Language': 'ja,en-US;q=0.9,en;q=0.8',
-            'Cache-Control': 'max-age=0',
-            'Cookie': 'your-cookie-here'
         }
+
+    # -------------------- 共通ユーティリティ --------------------
+    def _request(self, url, retries=_REQUEST_RETRIES):
+        """GET（リトライ/指数backoff付き）。成功時 response、失敗時 None。"""
+        for attempt in range(retries):
+            try:
+                r = requests.get(url, headers=self.headers, timeout=_REQUEST_TIMEOUT)
+                if r.status_code == 200:
+                    return r
+                logger.warning(f"HTTP {r.status_code}: {url}（{attempt + 1}/{retries}）")
+            except Exception as e:
+                logger.warning(f"リクエスト例外: {e}（{attempt + 1}/{retries}）")
+            if attempt < retries - 1:
+                time.sleep(2 ** attempt)
+        return None
 
     def extract_urls(self, text):
         github_pattern = r'https?://github\.com/\S+'
         huggingface_pattern = r'https?://huggingface\.co/\S+'
-
         github_urls = re.findall(github_pattern, text)
         huggingface_urls = re.findall(huggingface_pattern, text)
-
         return github_urls, huggingface_urls
 
+    @staticmethod
+    def _arxiv_id(s):
+        """URL/ID 文字列から arXiv id（版番号なし・bare）を取り出す。無ければ None。"""
+        m = re.search(r'(\d{4}\.\d{4,5})(v\d+)?', s or '')
+        return m.group(1) if m else None
+
+    def _arxiv_abs(self, s):
+        aid = self._arxiv_id(s)
+        return f"https://arxiv.org/abs/{aid}" if aid else None
+
+    def _hf_link(self, pid):
+        """HF paper.id が arXiv 形式なら arXiv abs URL、そうでなければ HF ペーパーページ。"""
+        aid = self._arxiv_id(pid)
+        return f"https://arxiv.org/abs/{aid}" if aid else f"https://huggingface.co/papers/{pid}"
+
+    @staticmethod
+    def _norm(text):
+        return ' '.join((text or '').split())
+
+    def _canon_key(self, paper):
+        """dedup キー：arXiv id が取れれば `arxiv:<id>`（http/https・/abs/・vN 差異を吸収）、
+        取れなければ link 完全一致（小文字）。※同一 run 内の papers.json 重複のみ防ぐ。
+        既存 GitHub Issue との重複は issue_creator 側の別課題。"""
+        aid = self._arxiv_id(paper.get('link', ''))
+        if aid:
+            return f"arxiv:{aid}"
+        return f"link:{(paper.get('link') or '').strip().lower()}"
+
+    # -------------------- arXiv（Atom API） --------------------
     def scrape_arxiv(self):
-        logger.info("arXivからの論文スクレイピングを開始します")
-        url = 'http://export.arxiv.org/rss/cs.AI'
-        response = requests.get(url, headers=self.headers)
-        logger.debug(f"arXivのステータスコード: {response.status_code}")
-        
-        if response.status_code != 200:
-            logger.error(f"arXivへのリクエストが失敗しました: {response.status_code}")
-            return []
+        """戻り値 (papers, fetch_failed)。fetch_failed=True は例外/非200（=真の障害）。"""
+        logger.info("arXivからの論文スクレイピングを開始します（Atom API）")
+        cats = '+OR+'.join(f'cat:{c}' for c in _ARXIV_CATEGORIES)
+        url = (f"{_ARXIV_API}?search_query={cats}"
+               f"&sortBy=submittedDate&sortOrder=descending&max_results={_ARXIV_MAX_RESULTS}")
+        r = self._request(url)
+        if r is None:
+            logger.error("arXiv API の取得に失敗しました（fetch_failed）")
+            return [], True
 
-        soup = BeautifulSoup(response.content, 'lxml-xml')
-        logger.debug(f"arXivのRSSフィードの内容: {soup.prettify()}")
-
-        items = soup.find_all('item')
-        logger.info(f"見つかったアイテム数: {len(items)}")
-
-        papers = []
-        for item in items:
-            try:
-                title = item.find('title').text if item.find('title') else 'タイトルなし'
-                description = item.find('description').text if item.find('description') else '説明なし'
-                link = item.find('link').text if item.find('link') else 'リンクなし'
-                published = item.find('pubDate').text if item.find('pubDate') else '日付なし'
-                
-                full_text = title + ' ' + description
-                github_urls, huggingface_urls = self.extract_urls(full_text)
-
-                paper = {
-                    'title': title,
-                    'summary': description,
-                    'link': link,
-                    'published': published,
-                    'github_urls': github_urls,
-                    'huggingface_urls': huggingface_urls,
-                    'source': 'arXiv'
-                }
-                papers.append(paper)
-                logger.debug(f"論文を追加しました: {title}")
-    
-            except AttributeError as e:
-                logger.error(f"arXivエントリーの処理中にエラーが発生しました: {str(e)}")
-                continue
-
-        logger.success(f"arXivから{len(papers)}件の論文を取得しました")
-        return papers
-
-    def scrape_huggingface(self):
-        logger.info("Hugging Faceからの論文スクレイピングを開始します")
-        url = 'http://rsshub.app/huggingface/daily-papers'
-        
-        response = requests.get(url, headers=self.headers)
-        logger.debug(f"ステータスコード: {response.status_code}")
-        
-        if response.status_code != 200:
-            logger.error(f"Hugging Faceへのリクエストが失敗しました: {response.status_code}")
-            return []
-
-        soup = BeautifulSoup(response.content, 'lxml-xml')
-        logger.debug(f"RSSフィードの内容: {soup.prettify()}")
-        
-        items = soup.find_all('item')
-        logger.info(f"見つかったアイテム数: {len(items)}")
+        soup = BeautifulSoup(r.content, 'lxml-xml')
+        entries = soup.find_all('entry')
+        logger.info(f"arXiv entries: {len(entries)}")
 
         papers = []
-        for item in items:
+        for e in entries:
             try:
-                title = item.find('title').text if item.find('title') else 'タイトルなし'
-                description = item.find('description').text if item.find('description') else '説明なし'
-                link = item.find('link').text if item.find('link') else 'リンクなし'
-                published = item.find('pubDate').text if item.find('pubDate') else '日付なし'
-                authors = item.find('author').text if item.find('author') else '著者なし'
-
-                # arXivからのリンクかどうかでソースを区別
-                if "arxiv.org" in link:
-                    source = "arXiv"
-                else:
-                    source = "Hugging Face"
-
-                full_text = title + ' ' + description
-                github_urls, huggingface_urls = self.extract_urls(full_text)
-                
-                paper = {
+                title = self._norm(e.find('title').text if e.find('title') else 'タイトルなし')
+                summary = self._norm(e.find('summary').text if e.find('summary') else '説明なし')
+                id_text = e.find('id').text if e.find('id') else ''
+                link = self._arxiv_abs(id_text) or (id_text or 'リンクなし')
+                published = e.find('published').text if e.find('published') else '日付なし'
+                authors = ", ".join(
+                    a.find('name').text for a in e.find_all('author') if a.find('name')
+                ) or '著者なし'
+                github_urls, huggingface_urls = self.extract_urls(title + ' ' + summary)
+                papers.append({
                     'title': title,
-                    'summary': description,
+                    'summary': summary,
                     'link': link,
                     'published': published,
                     'authors': authors,
                     'github_urls': github_urls,
                     'huggingface_urls': huggingface_urls,
-                    'source': source  # ソースを明示的に設定
-                }
-                papers.append(paper)
-                logger.debug(f"論文を追加しました: {title}")
+                    'source': 'arXiv',
+                })
+            except Exception as ex:
+                logger.error(f"arXivエントリーの処理中にエラー: {ex}")
+                continue
 
-            except Exception as e:
-                logger.error(f"Hugging Faceの論文取得中にエラーが発生しました: {str(e)}")
+        logger.success(f"arXivから{len(papers)}件の論文を取得しました")
+        return papers, False
+
+    # -------------------- HuggingFace（公式 daily_papers API） --------------------
+    def scrape_huggingface(self):
+        """戻り値 (papers, fetch_failed)。"""
+        logger.info("Hugging Faceからの論文スクレイピングを開始します（公式API）")
+        r = self._request(_HF_API)
+        if r is None:
+            logger.error("Hugging Face API の取得に失敗しました（fetch_failed）")
+            return [], True
+        try:
+            data = r.json()
+        except Exception as ex:
+            logger.error(f"Hugging Face API の JSON パースに失敗しました: {ex}（fetch_failed）")
+            return [], True
+
+        papers = []
+        for item in (data or []):
+            try:
+                p = item.get('paper', {}) or {}
+                title = self._norm(p.get('title') or item.get('title') or 'タイトルなし')
+                summary = self._norm(p.get('summary') or item.get('summary') or '説明なし')
+                pid = p.get('id') or ''
+                link = self._hf_link(pid)
+                published = item.get('publishedAt') or p.get('publishedAt') or '日付なし'
+                authors_list = p.get('authors') or []
+                authors = ", ".join(
+                    a.get('name', '') for a in authors_list
+                    if isinstance(a, dict) and a.get('name')
+                ) or '著者なし'
+                github_urls, huggingface_urls = self.extract_urls(title + ' ' + summary)
+                # 現行踏襲: arXiv リンクなら source='arXiv'、それ以外は 'Hugging Face'（スペースあり）
+                source = "arXiv" if "arxiv.org" in link else "Hugging Face"
+                papers.append({
+                    'title': title,
+                    'summary': summary,
+                    'link': link,
+                    'published': published,
+                    'authors': authors,
+                    'github_urls': github_urls,
+                    'huggingface_urls': huggingface_urls,
+                    'source': source,
+                })
+            except Exception as ex:
+                logger.error(f"Hugging Faceの論文処理中にエラー: {ex}")
                 continue
 
         logger.success(f"Hugging Faceから{len(papers)}件の論文を取得しました")
-        return papers
+        return papers, False
 
+    # -------------------- 統合・保存・終了コード --------------------
     def scrape(self):
         tprint(">>  PaperScraper", font="rnd-large")
         logger.info("論文スクレイピングを開始します")
-        arxiv_papers = self.scrape_arxiv()
-        huggingface_papers = self.scrape_huggingface()
+        arxiv_papers, arxiv_failed = self.scrape_arxiv()
+        hf_papers, hf_failed = self.scrape_huggingface()
 
-        all_papers = arxiv_papers + huggingface_papers
+        # dedup（arXiv を先に置く → arXiv が薄い/0 の日は先頭30件に HF が入り Issue が復活）
+        combined = []
+        seen = set()
+        for paper in arxiv_papers + hf_papers:
+            key = self._canon_key(paper)
+            if key in seen:
+                continue
+            seen.add(key)
+            combined.append(paper)
 
         with open(self.output_path, 'w', encoding='utf-8') as f:
-            json.dump(all_papers, f, ensure_ascii=False, indent=2)
+            json.dump(combined, f, ensure_ascii=False, indent=2)
 
-        logger.success(f"合計{len(all_papers)}件の論文を抽出しました")
-        logger.info(f"arXiv: {len(arxiv_papers)}件")
-        logger.info(f"Hugging Face: {len(huggingface_papers)}件")
+        total = len(combined)
+        logger.success(
+            f"合計{total}件の論文を抽出しました"
+            f"（arXiv {len(arxiv_papers)} / Hugging Face {len(hf_papers)} / dedup後 {total}）"
+        )
         logger.info(f"結果を {self.output_path} に保存しました")
+
+        # Fix C（結果ベース）: 障害は fail-loud、正当な空は warning
+        if total > 0:
+            if arxiv_failed:
+                logger.warning("arXiv 取得に失敗しましたが、他ソースで成果ありのため成功終了します")
+            if hf_failed:
+                logger.warning("Hugging Face 取得に失敗しましたが、他ソースで成果ありのため成功終了します")
+            return 0
+        if arxiv_failed or hf_failed:
+            logger.error("全ソース取得0件かつ障害（例外/非200）あり → 失敗終了 (exit 1)")
+            return 1
+        logger.warning("全ソース取得成功だが新着0件（正当な空）→ 成功終了 (exit 0)")
+        return 0
+
 
 if __name__ == '__main__':
     scraper = PaperScraper()
-    scraper.scrape()
+    exit_code = scraper.scrape()
+    sys.exit(exit_code)


### PR DESCRIPTION
## 背景
ai_mail_digest の朝のダイジェストで **GitHub Issues 0件**（例: 2026-07-11/12/06）が発生していた。根本原因を実ログ・実測で特定し修正する。

## 真因（実ログ・実測）
2つの取得ソースが同時に失敗すると papers.json が空になり、Issue化する論文が無くなる（かつ 0件でも SUCCESS 終了＝サイレント失敗）。
- **HuggingFace `rsshub.app/huggingface/daily-papers` = 恒常403**（公開RSSHubのブロック/レート制限）
- **arXiv `export.arxiv.org/rss/cs.AI` = 間欠的に0件**（07-06 月も0・曜日非依存。RSSフィードの取りこぼし）

07-12 実行ログ:
```
SUCCESS | arXivから0件の論文を取得しました
ERROR   | Hugging Faceへのリクエストが失敗しました: 403
SUCCESS | 合計0件の論文を抽出しました   ← サイレント失敗
```

## 変更（`.github/scripts/scraper.py` のみ）
- **HuggingFace**: 公式 `https://huggingface.co/api/daily_papers`（JSON・実測200/50件）へ置換。authors(list)→文字列化。id が arXiv 形式なら `arxiv.org/abs`、非arXivは `huggingface.co/papers` へフォールバック。
- **arXiv**: RSS → Atom API `export.arxiv.org/api/query`（cs.AI/cs.LG/cs.CL・submittedDate降順・max_results=50）。**降順取得で週末でも空にならない**。
- **dedup**: `canon(link)` 正規化（http/https・`/abs/`・`vN`・bare id を吸収）で同一 run 内の重複排除。arXiv を先に連結 → arXiv が薄い/0 の日は**先頭30件に HF が入り Issue が復活**（issue_creator は先頭30件のみ処理）。
- **fail-loud（結果ベース）**: `total>0`=exit0+warn / `total0 かつ 例外・非200`=exit1 / `total0 で全成功(正当な空)`=exit0+warn。**片系統が生きていれば止めない／週末の正当な0で偽アラートを出さない**。
- 各取得に**リトライ/指数backoff**。不安定な `Accept-Encoding: br/zstd` を除去し UA のみに。

## 互換性
- **papers.json スキーマは現行HFエントリ形状に一致**（`title/summary/link/published/authors/github_urls/huggingface_urls/source`、`source` は現行踏襲で arxivリンク→`arXiv`/他→`Hugging Face`）。
- `issue_creator.py` / `label_adder` / `issue_summarizer` は **無改修**（title/summary/link のみ参照・追加/欠落フィールド許容）。

## ローカル検証
- 実行: arXiv 50 + HF 50 → **dedup後 100件**・スキーマ一致・**exit 0**。
- Fix C 3分岐（両成功0→exit0 / 全0かつ障害→exit1 / HF障害+arXiv成果→exit0）を確認。
- dedup: 同一論文の `http/https + vN` 表記 → **1件**にマージを確認。

## 想定影響/ロールバック
- Issue化上限 `n=30`（issue_creator）は本PRでは変更しない（別スコープ）。既存Issueとの重複チェックも別課題。
- 問題時は本PR revert で復帰（papers.json スキーマ不変ゆえ下流無影響）。マージ後 `workflow_dispatch` で手動起動し Issue 生成を確認予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paper discovery from arXiv and Hugging Face’s daily papers feed.
  * Paper records now include author details and relevant GitHub or Hugging Face links.
  * Combined results are deduplicated for a cleaner paper list.

* **Bug Fixes**
  * Improved handling of temporary source failures with automatic retries.
  * Individual malformed entries no longer prevent other papers from being collected.
  * Scraping now reports failure status accurately when no results are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->